### PR TITLE
fix: route gpt-4o-transcribe to Responses API in client.audio.transcr…

### DIFF
--- a/src/openai/resources/audio/transcriptions.py
+++ b/src/openai/resources/audio/transcriptions.py
@@ -1,4 +1,17 @@
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+from openai._base_client import APIClient
+
+class AudioTranscriptions(APIClient):
+    def create(self, model: str, file: bytes, **kwargs):
+        # Route to Responses API for gpt-4o-transcribe models
+        if model.startswith("gpt-4o-transcribe"):
+            return self._client.responses.create(
+                model=model,
+                input=[{"role": "user", "content": [{"type": "input_audio", "audio": file}]}],
+                **kwargs
+            )
+        # Legacy Whisper transcription path
+        return self._post("/audio/transcriptions", body={"model": model}, files={"file": file}, **kwargs)
 
 from __future__ import annotations
 


### PR DESCRIPTION
…iptions.create (#2477)

### Summary
Fixes #2477 by routing `gpt-4o-transcribe` requests through the Responses API instead of the legacy transcriptions endpoint, which does not support these models.

### Changes
- Added conditional routing for `gpt-4o-transcribe` models in `AudioTranscriptions.create`.
- Ensured proper audio input formatting for Responses API.

### Why
`gpt-4o-transcribe` is a Realtime transcription model. The legacy transcription endpoint rejects it, resulting in "model does not support format" errors.

<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [ ] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Additional context & links
