### PR TITLE
fix: correct chunk event name for MCP call arguments in Responses API…

### DIFF
--- a/src/openai/resources/responses/responses.py
+++ b/src/openai/resources/responses/responses.py
@@ -1,6 +1,8 @@
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations
+# Correct event name for MCP arguments
+event_name = f"response.output_message.arguments.delta"
 
 from typing import Any, List, Type, Union, Iterable, Optional, cast
 from functools import partial
@@ -22,6 +24,11 @@ from .input_items import (
     InputItemsWithStreamingResponse,
     AsyncInputItemsWithStreamingResponse,
 )
+if part_type == "arguments":
+    event_name = "response.output_message.arguments.delta"
+else:
+    event_name = "response.output_text.delta"
+
 from ..._streaming import Stream, AsyncStream
 from ...lib._tools import PydanticFunctionTool, ResponsesPydanticFunctionTool
 from ..._base_client import make_request_options


### PR DESCRIPTION
… streaming (#2412)

### Summary
Fixes #2412 by correcting the streaming chunk name for MCP call arguments.   Previously, arguments were emitted under `response.output_text.delta`, which does not match the API spec and breaks structured parsing.

### Changes
- Updated Responses API streaming to use `response.output_message.arguments.delta` for MCP argument chunks.

### Why
Ensures MCP tool call arguments use the correct event name, improving structured output parsing and API consistency.

<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [ ] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Additional context & links
