### PR TITLE
Create stream.py

### DIFF
--- a/docs/guides/stream.py
+++ b/docs/guides/stream.py
@@ -1,0 +1,26 @@
+from openai import OpenAI
+client = OpenAI()
+
+with client.responses.stream(
+    model="gpt-4o-mini",
+    input="Hello world"
+) as stream:
+    for event in stream:
+        yield event  # forward chunks to client A
+      from fastapi import FastAPI
+from fastapi.responses import StreamingResponse
+
+app = FastAPI()
+
+@app.post("/chat")
+async def chat_proxy(payload: dict):
+    def event_generator():
+        with client.responses.stream(**payload) as stream:
+            for event in stream:
+                yield f"data: {event.json()}\n\n"
+    return StreamingResponse(event_generator(), media_type="text/event-stream")
+if payload.get("provider") == "openai":
+    client = OpenAI(api_key=OPENAI_KEY)
+elif payload.get("provider") == "anthropic":
+    client = Anthropic(api_key=ANTHROPIC_KEY)
+


### PR DESCRIPTION
docs: add guide for dynamic request forwarding with streaming (A → B → Provider) (#2365) ### Summary
Adds a usage guide for configuring openai-python in a proxy (B) to forward streaming responses to clients (A), supporting dynamic provider selection.

### Why
Many developers build middle-layer proxies for AI models and need to preserve streaming behavior dynamically. This doc provides a clear pattern using Server-Sent Events.

<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [ ] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Additional context & links
