### PR TITLE
Fix: Auto-add https:// prefix to azure_endpoint when missing (#2166)

### DIFF
--- a/src/openai/_client.py
+++ b/src/openai/_client.py
@@ -33,6 +33,9 @@ from ._base_client import (
     SyncAPIClient,
     AsyncAPIClient,
 )
+if azure_endpoint and not azure_endpoint.startswith(("http://", "https://")):
+    azure_endpoint = "https://" + azure_endpoint
+self._azure_endpoint = azure_endpoint
 
 if TYPE_CHECKING:
     from .resources import (


### PR DESCRIPTION
Fix Azure endpoint initialization when scheme is missing

- Added logic in `openai/_client.py` to prepend `https://` if `azure_endpoint` lacks a scheme
- Prevents connection errors when users provide only the hostname (e.g., "my-resource.openai.azure.com")
- Improves developer experience for Azure OpenAI usage
- Closes #2166

<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [ ] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Additional context & links
