### PR TITLE
feat: add SafeAsyncStream wrapper to prevent memory growth in long-li…

### DIFF
--- a/no_leak_async_stream.py
+++ b/no_leak_async_stream.py
@@ -1,0 +1,30 @@
+from openai import AsyncOpenAI
+from safe_async_stream import safe_async_stream
+
+client = AsyncOpenAI()
+
+async def main():
+    stream = client.chat.completions.stream(
+        model="gpt-4o",
+        messages=[{"role": "user", "content": "Hello"}]
+    )
+    async for event in safe_async_stream(stream, force_gc=True):
+        print(event)
+
+# Run with asyncio.run(main())
+import gc
+from typing import AsyncIterator, Any
+
+async def safe_async_stream(stream: AsyncIterator[Any], force_gc: bool = False):
+    """
+    Wraps an async streaming iterator and clears memory after each chunk.
+    Usage:
+        async for chunk in safe_async_stream(stream):
+            ...
+    """
+    async for chunk in stream:
+        yield chunk
+        del chunk
+        if force_gc:
+            gc.collect()
+


### PR DESCRIPTION
…ved streaming

### Description
Introduces `SafeAsyncStream`, a lightweight wrapper for streaming responses that explicitly clears references after each yield to prevent memory growth in long-running async applications.

### Why?
Async streaming responses may retain references to parsed chunks in long-lived processes, mimicking a memory leak. This wrapper ensures memory is freed promptly.

### Usage
Wrap any async generator:
```python
safe_stream = SafeAsyncStream(original_stream.__aiter__, force_gc=True)
async for event in safe_stream:
    ...

<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [ ] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Additional context & links
