### PR TITLE
Propagate timeout in client.beta.threads.runs.create_and_poll requests

### DIFF
--- a/src/openai/resources/beta/threads/runs/runs.py
+++ b/src/openai/resources/beta/threads/runs/runs.py
@@ -1,6 +1,31 @@
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations
+from typing import Optional, Any
+
+def create_and_poll(
+    self,
+    thread_id: str,
+    **kwargs: Any,
+) -> Any:
+    """
+    Create a run and poll until it is completed.
+    Supports timeout propagation for all underlying requests.
+    """
+    timeout = kwargs.pop("timeout", None)
+
+    # Step 1: Create the run
+    run = self.create(thread_id=thread_id, timeout=timeout, **kwargs)
+
+    # Step 2: Poll until completion
+    while run.status in ("queued", "in_progress"):
+        run = self.retrieve(
+            thread_id=thread_id,
+            run_id=run.id,
+            timeout=timeout
+        )
+    return run
+
 
 import typing_extensions
 from typing import List, Union, Iterable, Optional


### PR DESCRIPTION
Fix timeout not being respected in client.beta.threads.runs.create_and_poll

- Added support for passing `timeout` to both the initial create() call  and subsequent retrieve() calls during polling.
- Ensures user-specified timeout is properly enforced across all requests.

Fixes: #1855

<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [ ] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Additional context & links
