### PR TITLE
Force correct task field for audio transcription/translation in Azure…

### DIFF
--- a/src/openai/_client.py
+++ b/src/openai/_client.py
@@ -1,4 +1,80 @@
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+from typing import Any, Dict
+from ..._types import NOT_GIVEN, NotGiven
+from ..._client import SyncAPIClient, AsyncAPIClient
+
+class Transcriptions:
+    def __init__(self, client: SyncAPIClient, async_client: AsyncAPIClient):
+        self._client = client
+        self._async_client = async_client
+
+    def create(
+        self,
+        *,
+        model: str,
+        file: Any,
+        **params: Any,
+    ) -> Dict:
+        # Always enforce transcribe task
+        params["task"] = "transcribe"
+        return self._client.post(
+            f"/audio/transcriptions",
+            files={"file": file},
+            data={"model": model, **params},
+        )
+
+    async def create_async(
+        self,
+        *,
+        model: str,
+        file: Any,
+        **params: Any,
+    ) -> Dict:
+        # Always enforce transcribe task
+        params["task"] = "transcribe"
+        return await self._async_client.post(
+            f"/audio/transcriptions",
+            files={"file": file},
+            data={"model": model, **params},
+        )
+from typing import Any, Dict
+from ..._types import NOT_GIVEN, NotGiven
+from ..._client import SyncAPIClient, AsyncAPIClient
+
+class Translations:
+    def __init__(self, client: SyncAPIClient, async_client: AsyncAPIClient):
+        self._client = client
+        self._async_client = async_client
+
+    def create(
+        self,
+        *,
+        model: str,
+        file: Any,
+        **params: Any,
+    ) -> Dict:
+        # Always enforce translate task
+        params["task"] = "translate"
+        return self._client.post(
+            f"/audio/translations",
+            files={"file": file},
+            data={"model": model, **params},
+        )
+
+    async def create_async(
+        self,
+        *,
+        model: str,
+        file: Any,
+        **params: Any,
+    ) -> Dict:
+        # Always enforce translate task
+        params["task"] = "translate"
+        return await self._async_client.post(
+            f"/audio/translations",
+            files={"file": file},
+            data={"model": model, **params},
+        )
 
 from __future__ import annotations
 


### PR DESCRIPTION
… deployments

Fix Azure OpenAI audio behavior where transcriptions vs translations depended solely on deployment.

- Updated audio.transcriptions.create() to always include task="transcribe".
- Updated audio.translations.create() to always include task="translate".
- Ensures explicit and predictable behavior across OpenAI and Azure deployments.

Fixes: #1910

<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [ ] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Additional context & links
