### PR TITLE
Add responses.create() Support to AzureOpenAI and AsyncAzureOpenAI

### DIFF
--- a/src/openai/_client.py
+++ b/src/openai/_client.py
@@ -1,4 +1,50 @@
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+# openai/_client.py
+from .resources.responses import Responses  # <-- add this import at the top
+
+class AzureOpenAI(BaseClient):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Add the Responses API for Azure with Azure-specific path
+        self.responses = Responses(self, api_prefix="/openai/deployments/{deployment_id}/responses")
+# openai/_async_client.py
+from .resources.responses import AsyncResponses  # <-- add this import at the top
+
+class AsyncAzureOpenAI(AsyncBaseClient):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Add the Responses API for Azure with Azure-specific path
+        self.responses = AsyncResponses(self, api_prefix="/openai/deployments/{deployment_id}/responses")
+# openai/resources/responses.py
+
+class Responses:
+    def __init__(self, client, api_prefix="/v1/responses"):
+        self._client = client
+        self._api_prefix = api_prefix
+
+    def create(self, deployment_id: str, **kwargs):
+        """
+        Create a response for Azure OpenAI.
+        :param deployment_id: Azure deployment name (model).
+        :param kwargs: Request payload.
+        """
+        path = self._api_prefix.format(deployment_id=deployment_id)
+        return self._client._request("POST", path, json=kwargs)
+
+
+class AsyncResponses:
+    def __init__(self, client, api_prefix="/v1/responses"):
+        self._client = client
+        self._api_prefix = api_prefix
+
+    async def create(self, deployment_id: str, **kwargs):
+        """
+        Create a response for Azure OpenAI (async).
+        :param deployment_id: Azure deployment name (model).
+        :param kwargs: Request payload.
+        """
+        path = self._api_prefix.format(deployment_id=deployment_id)
+        return await self._client._request("POST", path, json=kwargs)
 
 from __future__ import annotations
 


### PR DESCRIPTION
This PR adds support for the unified Responses API (responses.create()) in both AzureOpenAI and AsyncAzureOpenAI clients, enabling Azure users to fully leverage GPT‑4o and other models using the new /responses endpoint.

<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [ ] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Additional context & links
