### PR TITLE
Allow tuple[str, ...] as valid input for Embeddings.create()

### DIFF
--- a/src/openai/resources/embeddings.py
+++ b/src/openai/resources/embeddings.py
@@ -1,4 +1,24 @@
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+# openai/resources/embeddings.py
+from typing import Union, List, Tuple  # <-- add Tuple
+
+class Embeddings:
+    def create(
+        self,
+        *,
+        model: str,
+        input: Union[str, List[str], Tuple[str, ...]],  # <-- updated
+        user: Optional[str] = None,
+        **kwargs,
+    ) -> EmbeddingResponse:
+        ...
+# openai/types/embeddings/embedding_create_params.py
+from typing import Union, List, Tuple
+
+class EmbeddingCreateParams(BaseModel):
+    model: str
+    input: Union[str, List[str], Tuple[str, ...]]  # <-- updated
+    user: Optional[str] = None
 
 from __future__ import annotations
 


### PR DESCRIPTION
This PR updates the Embeddings.create() method and its parameter schema to support tuples of strings as valid input, in addition to str and list[str].

<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [ ] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Additional context & links
