### PR TITLE
Fix httpx.PoolTimeout in SyncClient by Allowing Configurable Connecti…

### DIFF
--- a/src/openai/_client.py
+++ b/src/openai/_client.py
@@ -24,6 +24,19 @@ from ._utils import (
     is_mapping,
     get_async_library,
 )
+# openai/_client.py
+import httpx
+
+class OpenAI:
+    def __init__(self, *, timeout: float = 30.0, max_connections: int = 100, max_keepalive_connections: int = 20, **kwargs):
+        self._timeout = timeout
+        self._pool_limits = httpx.Limits(
+            max_connections=max_connections,
+            max_keepalive_connections=max_keepalive_connections
+        )
+        self._client = httpx.Client(timeout=self._timeout, limits=self._pool_limits)
+        super().__init__(**kwargs)
+
 from ._compat import cached_property
 from ._version import __version__
 from ._streaming import Stream as Stream, AsyncStream as AsyncStream
@@ -33,6 +46,19 @@ from ._base_client import (
     SyncAPIClient,
     AsyncAPIClient,
 )
+# openai/_async_client.py
+import httpx
+
+class AsyncOpenAI:
+    def __init__(self, *, timeout: float = 30.0, max_connections: int = 100, max_keepalive_connections: int = 20, **kwargs):
+        self._timeout = timeout
+        self._pool_limits = httpx.Limits(
+            max_connections=max_connections,
+            max_keepalive_connections=max_keepalive_connections
+        )
+        self._client = httpx.AsyncClient(timeout=self._timeout, limits=self._pool_limits)
+        super().__init__(**kwargs)
+
 
 if TYPE_CHECKING:
     from .resources import (


### PR DESCRIPTION
…on Pool Limits

This PR addresses frequent httpx.PoolTimeout errors in high-concurrency workloads when using the sync client.

<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [ ] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Additional context & links
