### PR TITLE
Add Optional name Field to ChatCompletionToolMessageParam

### DIFF
--- a/src/openai/types/chat/chat_completion_tool_message_param.py
+++ b/src/openai/types/chat/chat_completion_tool_message_param.py
@@ -1,6 +1,15 @@
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations
+# openai/types/chat/chat_completion_tool_message_param.py
+from typing import Literal, Optional
+from pydantic import BaseModel
+
+class ChatCompletionToolMessageParam(BaseModel):
+    role: Literal["tool"]
+    content: str
+    tool_call_id: str
+    name: Optional[str] = None  # <-- Added optional name
 
 from typing import Union, Iterable
 from typing_extensions import Literal, Required, TypedDict


### PR DESCRIPTION
This PR updates the ChatCompletionToolMessageParam type to include an optional name field, matching the API specification for tool call messages.

<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [ ] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Additional context & links
