### PR TITLE
Fix: Add fallback parsing for gpt-5-mini Responses API when output_te…

### DIFF
--- a/src/openai/types/responses.
+++ b/src/openai/types/responses.
@@ -254,17 +254,31 @@ class Response(BaseModel):
     """
 
     @property
-    def output_text(self) -> str:
-        """Convenience property that aggregates all `output_text` items from the `output`
-        list.
+def output_text(self) -> str:
+    """
+    Returns the generated text output for the Responses API.
 
-        If no `output_text` content blocks exist, then an empty string is returned.
-        """
-        texts: List[str] = []
-        for output in self.output:
-            if output.type == "message":
-                for content in output.content:
-                    if content.type == "output_text":
-                        texts.append(content.text)
+    Extended to handle cases where models like gpt-5-mini return only
+    'reasoning' type items without a standard message output.
+    """
+    if not self.output:
+        return ""
 
-        return "".join(texts)
+    texts = []
+
+    # Standard extraction for message items
+    for item in self.output:
+        if getattr(item, "type", None) == "message":
+            for content in getattr(item, "content", []) or []:
+                if getattr(content, "type", None) == "output_text" and getattr(content, "text", None):
+                    texts.append(content.text)
+
+    # Fallback extraction for reasoning items
+    if not texts:
+        for item in self.output:
+            if getattr(item, "type", None) == "reasoning":
+                for part in getattr(item, "content", []) or []:
+                    if hasattr(part, "text") and part.text:
+                        texts.append(part.text)
+
+    return "".join(texts)


### PR DESCRIPTION
…xt is empty

Fix gpt-5-mini Responses API empty output_text issue

- Added fallback extraction logic to handle cases where gpt-5-mini returns only 'reasoning' type items.
- Ensures that output_text is correctly populated by scanning both 'message' and 'reasoning' blocks.
- Maintains existing behavior for gpt-4o-mini and other models.
- Improves consistency of Responses API outputs across models.

<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [ ] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Additional context & links
