### PR TITLE
fix(evals): add missing Input forward reference to prevent NameError …

### DIFF
--- a/evals_input_patch_demo.py
+++ b/evals_input_patch_demo.py
@@ -1,0 +1,35 @@
+from typing import Any
+from openai import OpenAI
+import openai.resources.evals.evals as evals_mod
+
+# Fix missing forward reference
+evals_mod.Input = Any
+
+client = OpenAI()
+
+eval_cfg = client.evals.create(
+    name="visio_json_exact_match",
+    data_source_config={
+        "type": "custom",
+        "item_schema": {
+            "type": "object",
+            "properties": {
+                "prompt": {"type": "string"},
+                "expected": {"type": "string"}
+            },
+            "required": ["prompt", "expected"]
+        },
+        "include_sample_schema": True
+    },
+    testing_criteria=[
+        {
+            "type": "string_check",
+            "name": "Exact JSON match",
+            "operation": "eq",
+            "input": "{{sample.output_text}}",
+            "reference": "{{item.expected}}"
+        }
+    ]
+)
+
+print("Eval created successfully:", eval_cfg)


### PR DESCRIPTION
…in client.evals.create

### Summary
This PR fixes a bug in the `evals` resource where calling `client.evals.create()` raises: ### Summary
This PR fixes a bug in the `evals` resource where calling `client.evals.create()` raises:

<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [ ] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Additional context & links
